### PR TITLE
Nest hover rule inside the link block

### DIFF
--- a/sass/partials/sidebar/_base.scss
+++ b/sass/partials/sidebar/_base.scss
@@ -43,9 +43,6 @@ aside.sidebar {
   a {
     color: inherit;
     @include transition(color .5s);
-  }
-  &:hover a {
-    color: $sidebar-link-color;
     &:hover { color: $sidebar-link-color-hover; }
   }
 }


### PR DESCRIPTION
Hello,

I'm using your theme for my new octopress blog, and I noticed that if I hovered over any part of the sidebar, all the links changed color.  I updated the CSS file so that individual links change when hovered over directly.  Based on your CSS, the links are not colored to look like links, so I left it that way, but I can also change the file to display link colors instead of black text if you want.
